### PR TITLE
Feature/1 room guard

### DIFF
--- a/client/src/components/ChatWindow/RoomsList/index.tsx
+++ b/client/src/components/ChatWindow/RoomsList/index.tsx
@@ -20,11 +20,11 @@ interface RoomListItemProps {
 const RoomListItem = ({ skipGlobalIcon, currentRoom, listedRoom }: RoomListItemProps) => {
   return (
     <li
-      title={listedRoom.public ? "Public" : "Private"}
+      title={listedRoom.isPublic ? "Public" : "Private"}
       className={`flex items-center gap-1 ${currentRoom === listedRoom.name ? "font-bold" : ""}`}
       key={listedRoom.id}>
       <Link to={`/chat?room=${listedRoom.name}`}>{listedRoom.name}</Link>
-      {!skipGlobalIcon && listedRoom.public && <img src="/public.png" width="12" height="12" />}
+      {!skipGlobalIcon && listedRoom.isPublic && <img src="/public.png" width="12" height="12" />}
     </li>
   );
 };

--- a/client/src/context/messages/context.tsx
+++ b/client/src/context/messages/context.tsx
@@ -39,6 +39,7 @@ export const MessagesProvider = ({ children }: Props) => {
   const [loading, setLoading] = useState(true);
 
   // Make sure we're allowed in the requested room. If not, redirect to /chat?room=abc
+  // TODO: This still allows a brief render. Move this to another protected route or... something.
   useEffect(() => {
     const controller = new AbortController();
     setLoading(() => true);

--- a/client/src/context/messages/context.tsx
+++ b/client/src/context/messages/context.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useCallback, useEffect, useRef, useState } from "react";
-import { useLoaderData } from "react-router-dom";
+import { useLoaderData, useNavigate } from "react-router-dom";
 import logger from "../../logger";
 import { ChatLoaderType } from "../../routes/chat";
 import { MessageError } from "./errors";
@@ -33,25 +33,65 @@ type Props = {
 
 export const MessagesProvider = ({ children }: Props) => {
   const eventSrcRef = useRef<EventSource>();
+  const navigate = useNavigate();
   const { room } = useLoaderData() as ChatLoaderType;
   const listeners = useRef<Record<string, CallableFunction>>({});
   const [loading, setLoading] = useState(true);
 
+  // Make sure we're allowed in the requested room. If not, redirect to /chat?room=abc
   useEffect(() => {
     const controller = new AbortController();
     setLoading(() => true);
-    fetch("http://localhost:9000/online", {
+    fetch(`http://localhost:9000/getRoom`, {
       method: "POST",
       credentials: "include",
       signal: controller.signal,
       body: JSON.stringify({ room }),
       headers: { "Content-Type": "application/json" },
     })
-      .then(() => setLoading(() => false))
-      .catch(console.warn);
+      .then((res) => {
+        console.log({ res });
+        if (!res.ok) {
+          logger.warn("Ooopsie");
+          navigate("/chat?room=abc");
+        }
+      })
+      .finally(() => setLoading(false));
 
     return () => {
       controller.abort("New room chosen");
+    };
+  }, [room, navigate]);
+
+  useEffect(() => {
+    eventSrcRef.current = new EventSource(`http://localhost:9000/events?room=${room}`, {
+      withCredentials: true,
+    });
+
+    const evt = eventSrcRef.current;
+    evt.addEventListener("message", onMessage);
+    evt.addEventListener("error", onError);
+    window.addEventListener("beforeunload", () => {
+      evt.close();
+      console.log("Closing SSE", eventSrcRef.current?.readyState === EventSource.CLOSED);
+    });
+
+    function onMessage(message: MessageEvent) {
+      const msg = JSON.parse(message.data);
+      listeners.current[msg.room]?.(msg.data);
+    }
+
+    function onError(e: Event) {
+      console.warn("!!! EventSource error", e);
+    }
+
+    return () => {
+      if (!evt) {
+        return logger.warn("eventSrcRef is null");
+      }
+      evt.removeEventListener("message", onMessage);
+      evt.removeEventListener("error", onError);
+      evt.close();
     };
   }, [room]);
 
@@ -95,39 +135,13 @@ export const MessagesProvider = ({ children }: Props) => {
       credentials: "include",
     });
 
+    if (!response.ok) {
+      console.warn("Unable to get channel messages", response);
+      // TODO: Navigate to 404
+      navigate("/404", { replace: true });
+    }
+
     return await response.json();
-  }, [room]);
-
-  useEffect(() => {
-    eventSrcRef.current = new EventSource(`http://localhost:9000/events?room=${room}`, {
-      withCredentials: true,
-    });
-
-    const evt = eventSrcRef.current;
-    evt.addEventListener("message", onMessage);
-    evt.addEventListener("error", onError);
-    window.addEventListener("beforeunload", () => {
-      evt.close();
-      console.log("Closing SSE", eventSrcRef.current?.readyState === EventSource.CLOSED);
-    });
-
-    function onMessage(message: MessageEvent) {
-      const msg = JSON.parse(message.data);
-      listeners.current[msg.room]?.(msg.data);
-    }
-
-    function onError(e: Event) {
-      console.warn("!!! EventSource error", e);
-    }
-
-    return () => {
-      if (!evt) {
-        return logger.warn("eventSrcRef is null");
-      }
-      evt.removeEventListener("message", onMessage);
-      evt.removeEventListener("error", onError);
-      evt.close();
-    };
   }, [room]);
 
   return (

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -53,6 +53,10 @@ const router = createBrowserRouter([
           };
         },
       },
+      {
+        path: "*",
+        element: <div>Not found</div>,
+      },
     ],
   },
 ]);

--- a/client/src/routes/protected/index.tsx
+++ b/client/src/routes/protected/index.tsx
@@ -3,6 +3,7 @@ import { useAuthContext } from "../../context/auth/hook";
 
 export default function ProtectedRoutes() {
   const { loading, user } = useAuthContext();
+
   if (loading) {
     return;
   }

--- a/client/src/types/room.ts
+++ b/client/src/types/room.ts
@@ -5,5 +5,5 @@ export interface ChatRoom {
   name: string;
   createdBy: string;
   createdAt: number;
-  public: boolean;
+  isPublic: boolean;
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,7 @@ import roomRoutes from "./routes/rooms.ts";
 import sseRoutes from "./routes/sse.ts";
 import { DEFAULT_ROOM } from "./data/models.ts";
 import { db } from "./data/index.ts";
+import { ChatRoom } from "../client/src/types/room.ts";
 
 const router = new Router();
 
@@ -16,9 +17,9 @@ try {
     id: "0001",
     name: DEFAULT_ROOM,
     createdBy: "__admin__",
-    public: true,
+    isPublic: true,
     createdAt: Date.now(),
-  });
+  } as ChatRoom);
 } catch (e) {
   console.warn("Error setting up", e);
 }

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -46,10 +46,8 @@ router.post("/login", async ({ response, request, cookies }) => {
   // All good, set cookie and return ok
   await cookies.set(AUTH_COOKIE_NAME, username, COOKIE_OPTIONS);
 
-  const presenceCookie = await cookies.get(AUTH_PRESENCE_COOKIE);
-  if (!presenceCookie) {
-    await cookies.set(AUTH_PRESENCE_COOKIE, DEFAULT_ROOM, COOKIE_OPTIONS);
-  }
+  // Set the default presence room to the default room
+  await cookies.set(AUTH_PRESENCE_COOKIE, DEFAULT_ROOM, COOKIE_OPTIONS);
 
   response.body = { ok: true };
 });

--- a/server/utils/room.ts
+++ b/server/utils/room.ts
@@ -1,0 +1,17 @@
+import { type ChatRoom } from "../../client/src/types/room.ts";
+import { db } from "../data/index.ts";
+
+export async function canAccess(room: string, username: string): Promise<boolean> {
+  // Ensure the user has permission to read the messages from the requested room
+  const rows = await Array.fromAsync(db.list<ChatRoom>({ prefix: ["rooms"] }));
+  const target = rows.find((row) => {
+    // Key is ["room", "username", roomName]
+    return row.key[2] === room;
+  });
+
+  if (!target || (!target.value.isPublic && target.value.createdBy !== username)) {
+    return false;
+  }
+
+  return true;
+}

--- a/server/utils/room.ts
+++ b/server/utils/room.ts
@@ -1,9 +1,14 @@
 import { type ChatRoom } from "../../client/src/types/room.ts";
 import { db } from "../data/index.ts";
 
+/**
+ * Grab all rooms and search for the room in the store key. Might need to refactor this at some
+ * point to narrow down the query size as the rooms are created via [rooms, user, roomname]
+ */
 export async function canAccess(room: string, username: string): Promise<boolean> {
   // Ensure the user has permission to read the messages from the requested room
   const rows = await Array.fromAsync(db.list<ChatRoom>({ prefix: ["rooms"] }));
+
   const target = rows.find((row) => {
     // Key is ["room", "username", roomName]
     return row.key[2] === room;


### PR DESCRIPTION
When a user attempts to join a room, either via the UI or manually by adjusting the search params, this checks to see if the room is public or created by the user. If either fails, redirect to /404 (which needs to be make as of this commit).

- Update the `ChatRoom` interface property `public` to `isPublic` as that was causing some issues in destructuring
-